### PR TITLE
Functionality for pre-computed ref log probs

### DIFF
--- a/recipes/configs/qwen2_5/0.5B_lora_dpo_single_device.yaml
+++ b/recipes/configs/qwen2_5/0.5B_lora_dpo_single_device.yaml
@@ -13,9 +13,8 @@
 #
 # This config works only for training on single device.
 
-output_dir: /tmp/torchtune/qwen2_5_0_5B/lora_single_device # /tmp may be deleted by your system. Change it to your preference.
+output_dir: /tmp/torchtune/qwen2_5_0_5B/lora_dpo_single_device # /tmp may be deleted by your system. Change it to your preference.
 precompute_ref_log_probs: True
-batch_size: 8
 
 # Model arguments
 model:
@@ -60,18 +59,18 @@ shuffle: True
 # Fine-tuning arguments
 epochs: 1
 max_steps_per_epoch: null
-batch_size: 2
+batch_size: 8
 gradient_accumulation_steps: 8 # Use to increase effective batch size
 optimizer:
   _component_: torch.optim.AdamW
   fused: True
-  weight_decay: 0.01
-  lr: 2e-3
+  weight_decay: 0.05
+  lr: 5e-4
 lr_scheduler:
   _component_: torchtune.training.lr_schedulers.get_cosine_schedule_with_warmup
   num_warmup_steps: 100
 loss:
-  _component_: torchtune.modules.loss.CEWithChunkedOutputLoss
+  _component_: torchtune.rlhf.loss.DPOLoss
 
 # Training env
 device: cuda
@@ -88,28 +87,3 @@ metric_logger:
   log_dir: ${output_dir}/logs
 log_every_n_steps: 1
 log_peak_memory_stats: True
-
-# Profiler (disabled)
-profiler:
-  _component_: torchtune.training.setup_torch_profiler
-  enabled: False
-
-  #Output directory of trace artifacts
-  output_dir: ${output_dir}/profiling_outputs
-
-  #`torch.profiler.ProfilerActivity` types to trace
-  cpu: True
-  cuda: True
-
-  #trace options passed to `torch.profiler.profile`
-  profile_memory: False
-  with_stack: False
-  record_shapes: True
-  with_flops: False
-
-  # `torch.profiler.schedule` options:
-  # wait_steps -> wait, warmup_steps -> warmup, active_steps -> active, num_cycles -> repeat
-  wait_steps: 5
-  warmup_steps: 3
-  active_steps: 2
-  num_cycles: 1

--- a/recipes/configs/qwen2_5/0.5B_lora_dpo_single_device.yaml
+++ b/recipes/configs/qwen2_5/0.5B_lora_dpo_single_device.yaml
@@ -1,0 +1,115 @@
+# Config for single device LoRA finetuning in lora_finetune_single_device.py
+# using a Qwen2.5 0.5B model
+#
+# This config assumes that you've run the following command before launching
+#   tune download Qwen/Qwen2.5-0.5B-Instruct
+#
+# To launch on a single device, run the following command from root:
+#   tune run lora_finetune_single_device --config qwen2_5/0.5B_lora_single_device
+#
+# You can add specific overrides through the command line. For example
+# to override the checkpointer directory while launching training:
+#   tune run lora_finetune_single_device --config qwen2_5/0.5B_lora_single_device checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
+#
+# This config works only for training on single device.
+
+output_dir: /tmp/torchtune/qwen2_5_0_5B/lora_single_device # /tmp may be deleted by your system. Change it to your preference.
+precompute_ref_log_probs: True
+batch_size: 8
+
+# Model arguments
+model:
+  _component_: torchtune.models.qwen2_5.lora_qwen2_5_0_5b
+  lora_attn_modules: ["q_proj", "v_proj", "output_proj"]
+  apply_lora_to_mlp: True
+  apply_lora_to_output: False
+  lora_rank: 32 # higher increases accuracy and memory
+  lora_alpha: 64 # usually alpha=2*rank
+  lora_dropout: 0.0
+
+# Tokenizer
+tokenizer:
+  _component_: torchtune.models.qwen2_5.qwen2_5_tokenizer
+  path: /tmp/Qwen2.5-0.5B-Instruct/vocab.json
+  merges_file: /tmp/Qwen2.5-0.5B-Instruct/merges.txt
+  max_seq_len: null
+
+# Checkpointer
+checkpointer:
+  _component_: torchtune.training.FullModelHFCheckpointer
+  checkpoint_dir: /tmp/Qwen2.5-0.5B-Instruct
+  checkpoint_files: [model.safetensors]
+  recipe_checkpoint: null
+  output_dir: ${output_dir}
+  model_type: QWEN2
+resume_from_checkpoint: False
+
+# Dataset
+dataset:
+  _component_: torchtune.datasets.preference_dataset
+  packed: False # True increases speed
+  source: json
+  data_files: /content/DPO-dataset-train.jsonl # /content/ for colab
+  column_map:
+    chosen: chosen
+    rejected: rejected
+  split: train
+seed: null
+shuffle: True
+
+# Fine-tuning arguments
+epochs: 1
+max_steps_per_epoch: null
+batch_size: 2
+gradient_accumulation_steps: 8 # Use to increase effective batch size
+optimizer:
+  _component_: torch.optim.AdamW
+  fused: True
+  weight_decay: 0.01
+  lr: 2e-3
+lr_scheduler:
+  _component_: torchtune.training.lr_schedulers.get_cosine_schedule_with_warmup
+  num_warmup_steps: 100
+loss:
+  _component_: torchtune.modules.loss.CEWithChunkedOutputLoss
+
+# Training env
+device: cuda
+
+# Memory management / performance
+enable_activation_checkpointing: False # True reduces memory
+enable_activation_offloading: False # True reduces memory
+dtype: bf16
+compile: False # torch.compile the model + loss, True increases speed + decreases memory
+
+# Logging
+metric_logger:
+  _component_: torchtune.training.metric_logging.DiskLogger
+  log_dir: ${output_dir}/logs
+log_every_n_steps: 1
+log_peak_memory_stats: True
+
+# Profiler (disabled)
+profiler:
+  _component_: torchtune.training.setup_torch_profiler
+  enabled: False
+
+  #Output directory of trace artifacts
+  output_dir: ${output_dir}/profiling_outputs
+
+  #`torch.profiler.ProfilerActivity` types to trace
+  cpu: True
+  cuda: True
+
+  #trace options passed to `torch.profiler.profile`
+  profile_memory: False
+  with_stack: False
+  record_shapes: True
+  with_flops: False
+
+  # `torch.profiler.schedule` options:
+  # wait_steps -> wait, warmup_steps -> warmup, active_steps -> active, num_cycles -> repeat
+  wait_steps: 5
+  warmup_steps: 3
+  active_steps: 2
+  num_cycles: 1

--- a/recipes/configs/qwen2_5/0.5B_lora_single_device.yaml
+++ b/recipes/configs/qwen2_5/0.5B_lora_single_device.yaml
@@ -14,14 +14,17 @@
 # This config works only for training on single device.
 
 output_dir: /tmp/torchtune/qwen2_5_0_5B/lora_single_device # /tmp may be deleted by your system. Change it to your preference.
+precompute_ref_log_probs: True
+batch_size: 8
 
 # Model arguments
 model:
   _component_: torchtune.models.qwen2_5.lora_qwen2_5_0_5b
-  lora_attn_modules: ['q_proj', 'v_proj', 'output_proj']
+  lora_attn_modules: ["q_proj", "v_proj", "output_proj"]
   apply_lora_to_mlp: True
-  lora_rank: 32  # higher increases accuracy and memory
-  lora_alpha: 64  # usually alpha=2*rank
+  apply_lora_to_output: False
+  lora_rank: 32 # higher increases accuracy and memory
+  lora_alpha: 64 # usually alpha=2*rank
   lora_dropout: 0.0
 
 # Tokenizer
@@ -43,8 +46,14 @@ resume_from_checkpoint: False
 
 # Dataset
 dataset:
-  _component_: torchtune.datasets.alpaca_cleaned_dataset
-  packed: False  # True increases speed
+  _component_: torchtune.datasets.preference_dataset
+  packed: False # True increases speed
+  source: json
+  data_files: /content/DPO-dataset-train.jsonl # /content/ for colab
+  column_map:
+    chosen: chosen
+    rejected: rejected
+  split: train
 seed: null
 shuffle: True
 
@@ -52,7 +61,7 @@ shuffle: True
 epochs: 1
 max_steps_per_epoch: null
 batch_size: 2
-gradient_accumulation_steps: 8  # Use to increase effective batch size
+gradient_accumulation_steps: 8 # Use to increase effective batch size
 optimizer:
   _component_: torch.optim.AdamW
   fused: True
@@ -68,10 +77,10 @@ loss:
 device: cuda
 
 # Memory management / performance
-enable_activation_checkpointing: False  # True reduces memory
-enable_activation_offloading: False  # True reduces memory
+enable_activation_checkpointing: False # True reduces memory
+enable_activation_offloading: False # True reduces memory
 dtype: bf16
-compile: False  # torch.compile the model + loss, True increases speed + decreases memory
+compile: False # torch.compile the model + loss, True increases speed + decreases memory
 
 # Logging
 metric_logger:
@@ -79,7 +88,6 @@ metric_logger:
   log_dir: ${output_dir}/logs
 log_every_n_steps: 1
 log_peak_memory_stats: True
-
 
 # Profiler (disabled)
 profiler:

--- a/recipes/configs/qwen2_5/0.5B_lora_single_device.yaml
+++ b/recipes/configs/qwen2_5/0.5B_lora_single_device.yaml
@@ -14,15 +14,12 @@
 # This config works only for training on single device.
 
 output_dir: /tmp/torchtune/qwen2_5_0_5B/lora_single_device # /tmp may be deleted by your system. Change it to your preference.
-precompute_ref_log_probs: True
-batch_size: 8
 
 # Model arguments
 model:
   _component_: torchtune.models.qwen2_5.lora_qwen2_5_0_5b
   lora_attn_modules: ["q_proj", "v_proj", "output_proj"]
   apply_lora_to_mlp: True
-  apply_lora_to_output: False
   lora_rank: 32 # higher increases accuracy and memory
   lora_alpha: 64 # usually alpha=2*rank
   lora_dropout: 0.0
@@ -46,14 +43,8 @@ resume_from_checkpoint: False
 
 # Dataset
 dataset:
-  _component_: torchtune.datasets.preference_dataset
+  _component_: torchtune.datasets.alpaca_cleaned_dataset
   packed: False # True increases speed
-  source: json
-  data_files: /content/DPO-dataset-train.jsonl # /content/ for colab
-  column_map:
-    chosen: chosen
-    rejected: rejected
-  split: train
 seed: null
 shuffle: True
 

--- a/recipes/lora_dpo_single_device.py
+++ b/recipes/lora_dpo_single_device.py
@@ -425,6 +425,8 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
         else:
             ds = config.instantiate(cfg_dataset, tokenizer=self._tokenizer)
 
+        print(f'\nPrecompute configured as: {self._precompute_ref_log_probs}')
+
         if self._precompute_ref_log_probs:
             '''
             We can pre-compute the reference log_probs for (chosen,rejected)_ids. 

--- a/recipes/lora_dpo_single_device.py
+++ b/recipes/lora_dpo_single_device.py
@@ -602,7 +602,8 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
             # in case shuffle is True
             self._sampler.set_epoch(curr_epoch)
             pbar = tqdm(total=self._steps_per_epoch)
-            self._dataloader.dataset.clear_ref_log_probs()
+            if self._precompute_ref_log_probs:
+                self._dataloader.dataset.clear_ref_log_probs()
 
             for idx, batch in enumerate(self._dataloader):
                 if (

--- a/recipes/lora_dpo_single_device.py
+++ b/recipes/lora_dpo_single_device.py
@@ -425,7 +425,7 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
         else:
             ds = config.instantiate(cfg_dataset, tokenizer=self._tokenizer)
 
-        print(f'\nPrecompute configured as: {self._precompute_ref_log_probs}')
+        print(f'Precompute ref log probs configured as: {self._precompute_ref_log_probs}')
 
         if self._precompute_ref_log_probs:
             '''

--- a/recipes/lora_dpo_single_device.py
+++ b/recipes/lora_dpo_single_device.py
@@ -35,6 +35,43 @@ from tqdm import tqdm
 log = utils.get_logger("DEBUG")
 
 
+class PrecomputedDataset(torch.utils.data.Dataset):
+    '''
+    A custom dataset implementation which behaves similar to what
+    DPO expects, but maintains the cache of the current batch's
+    precomputed referecen model log probs. This helps the training
+    loop by avoiding multiple forward passes: one for policy and 
+    one for reference log probs.
+    '''
+    def __init__(self, base_dataset, reference_chosen_log_probs, reference_rejected_log_probs):
+        super().__init__()
+        length_check = len(base_dataset) == len(reference_chosen_log_probs) and len(base_dataset) == len(reference_rejected_log_probs)
+        assert length_check, f"Length mismatch between base dataset ({len(base_dataset)}) and extra columns ({len(reference_chosen_log_probs)}, {len(reference_rejected_log_probs)})"
+        self.base_dataset = base_dataset
+        self.reference_chosen_log_probs = reference_chosen_log_probs
+        self.reference_rejected_log_probs = reference_rejected_log_probs
+        self.cache_ref_chosen_log_prob = []
+        self.cache_ref_rejected_log_prob = []
+
+    def __len__(self):
+        return len(self.base_dataset)
+
+    def __getitem__(self, idx):
+        data = self.base_dataset[idx]
+        ref_chosen_log_probs = self.reference_chosen_log_probs[idx]
+        ref_rejected_log_probs = self.reference_rejected_log_probs[idx]
+        self.cache_ref_chosen_log_prob.append(ref_chosen_log_probs)
+        self.cache_ref_rejected_log_prob.append(ref_rejected_log_probs)
+        return data
+    
+    def clear_ref_log_probs(self):
+        self.cache_ref_chosen_log_prob = []
+        self.cache_ref_rejected_log_prob = []
+
+    def get_ref_log_probs(self):
+        return torch.tensor(self.cache_ref_chosen_log_prob).float(), torch.tensor(self.cache_ref_rejected_log_prob).float()
+
+
 class LoRADPORecipeSingleDevice(FTRecipeInterface):
     """
     LoRA DPO recipe for dense transformer-based LLMs such as Llama2 for
@@ -136,6 +173,9 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
         self._resume_from_checkpoint = cfg.resume_from_checkpoint
         self._save_adapter_weights_only = cfg.get("save_adapter_weights_only", False)
         self._gradient_accumulation_steps = cfg.gradient_accumulation_steps
+        self._precompute_ref_log_probs = cfg.get(
+            "precompute_ref_log_probs", False
+        )
 
     def load_checkpoint(self, cfg_checkpointer: DictConfig) -> Dict[str, Any]:
         """
@@ -374,6 +414,8 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
         Map-style Datasets which fit into memory and an option for random shuffling.
         Samplers, iterable datasets, and streaming datasets are not supported.
         """
+
+        utils.log_rank_zero(log, "\nCUSTOM IMPLEMENTATION\n")
         if isinstance(cfg_dataset, ListConfig):
             datasets = [
                 config.instantiate(single_cfg_dataset, tokenizer=self._tokenizer)
@@ -382,6 +424,56 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
             ds = ConcatDataset(datasets=datasets)
         else:
             ds = config.instantiate(cfg_dataset, tokenizer=self._tokenizer)
+
+        if self._precompute_ref_log_probs:
+            '''
+            We can pre-compute the reference log_probs for (chosen,rejected)_ids. 
+            This can then be added to the dataset as columns, and the training loop
+            can be modified to prevent calculating the ref log probs, improving
+            training time.
+
+            References: 
+                [1] Pre-compute: https://github.com/huggingface/trl/blob/v0.13.0/trl/trainer/dpo_trainer.py#L712
+                [2] Understanding existing implementation: Claude (https://claude.ai/)
+                [3] DataLoader behaviour: https://pytorch.org/docs/stable/data.html#module-torch.utils.data
+            '''
+
+            sampler = DistributedSampler(
+                ds, num_replicas=1, rank=0, shuffle=False, seed=0
+            )
+            
+            dataloader = DataLoader(
+                dataset=ds,
+                batch_size=batch_size,
+                sampler=sampler,
+                # dropping last avoids shape issues with compile + flex attention
+                # drop_last=True,
+                collate_fn=partial(
+                    padded_collate_dpo,
+                    padding_idx=self._tokenizer.pad_id,
+                    ignore_idx=CROSS_ENTROPY_IGNORE_IDX,
+                ),
+            )
+
+            all_reference_chosen_log_probs = []
+            all_reference_rejected_log_probs = []
+            
+            with torch.no_grad(), disable_adapter(self._model):
+                for batch in tqdm(dataloader, "Pre-compute reference log probs"): 
+                    (
+                        reference_chosen_log_probs,
+                        reference_rejected_log_probs,
+                        _,
+                        _,
+                    ) = self.concatenated_forward(self._model, batch)
+
+                    all_reference_chosen_log_probs.append(reference_chosen_log_probs.cpu())
+                    all_reference_rejected_log_probs.append(reference_rejected_log_probs.cpu())
+
+                all_reference_chosen_log_probs = torch.concat(all_reference_chosen_log_probs).float()
+                all_reference_rejected_log_probs = torch.concat(all_reference_rejected_log_probs).float()
+
+            ds = PrecomputedDataset(ds, all_reference_chosen_log_probs, all_reference_rejected_log_probs)
 
         sampler = DistributedSampler(
             ds,
@@ -508,6 +600,8 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
             # in case shuffle is True
             self._sampler.set_epoch(curr_epoch)
             pbar = tqdm(total=self._steps_per_epoch)
+            self._dataloader.dataset.clear_ref_log_probs()
+
             for idx, batch in enumerate(self._dataloader):
                 if (
                     self.max_steps_per_epoch is not None
@@ -531,13 +625,20 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
                 # deleting logits here helps reduce (peak) memory usage - we only need them for metric logging
                 del policy_chosen_logits, policy_rejected_logits
 
-                with torch.no_grad(), disable_adapter(self._model):
-                    (
-                        reference_chosen_log_probs,
-                        reference_rejected_log_probs,
-                        _,
-                        _,
-                    ) = self.concatenated_forward(self._model, batch)
+                if self._precompute_ref_log_probs:
+                    reference_chosen_log_probs, reference_rejected_log_probs = self._dataloader.dataset.get_ref_log_probs()
+                    reference_chosen_log_probs = reference_chosen_log_probs.to(device=self._device)
+                    reference_rejected_log_probs = reference_rejected_log_probs.to(device=self._device)
+                    self._dataloader.dataset.clear_ref_log_probs()
+                else:
+                    with torch.no_grad(), disable_adapter(self._model):
+                        (
+                            reference_chosen_log_probs,
+                            reference_rejected_log_probs,
+                            _,
+                            _,
+                        ) = self.concatenated_forward(self._model, batch)
+
                 loss, chosen_rewards, rejected_rewards = self._loss_fn(
                     policy_chosen_log_probs,
                     policy_rejected_log_probs,

--- a/recipes/lora_dpo_single_device.py
+++ b/recipes/lora_dpo_single_device.py
@@ -586,6 +586,9 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
         """
         The core training loop.
         """
+        pytorch_total_params = sum(p.numel() for p in self._model.parameters())
+        pytorch_trainable_params = sum(p.numel() for p in self._model.parameters() if p.requires_grad)
+        print(f"{pytorch_total_params=}, {pytorch_trainable_params=}")
         if self._model_compile:
             log.info(
                 "NOTE: torch.compile is enabled and model is compiled in first forward. Expect a relatively slow first iteration."

--- a/recipes/lora_dpo_single_device.py
+++ b/recipes/lora_dpo_single_device.py
@@ -588,7 +588,7 @@ class LoRADPORecipeSingleDevice(FTRecipeInterface):
         """
         pytorch_total_params = sum(p.numel() for p in self._model.parameters())
         pytorch_trainable_params = sum(p.numel() for p in self._model.parameters() if p.requires_grad)
-        print(f"{pytorch_total_params=}, {pytorch_trainable_params=}")
+        print(f"Model: {self._model} \nParams-> total:{pytorch_total_params=}, trainable:{pytorch_trainable_params=}")
         if self._model_compile:
             log.info(
                 "NOTE: torch.compile is enabled and model is compiled in first forward. Expect a relatively slow first iteration."

--- a/torchtune/_recipe_registry.py
+++ b/torchtune/_recipe_registry.py
@@ -312,8 +312,8 @@ _ALL_RECIPES = [
                 file_path="llama3_1/8B_lora_dpo_single_device.yaml",
             ),
             Config(
-                name="qwen2_5/0.5B_lora_single_device",
-                file_path="qwen2_5/0.5B_lora_single_device.yaml",
+                name="qwen2_5/0.5B_lora_dpo_single_device",
+                file_path="qwen2_5/0.5B_lora_dpo_single_device.yaml",
             )
         ],
         supports_distributed=False,

--- a/torchtune/_recipe_registry.py
+++ b/torchtune/_recipe_registry.py
@@ -311,6 +311,10 @@ _ALL_RECIPES = [
                 name="llama3_1/8B_lora_dpo_single_device",
                 file_path="llama3_1/8B_lora_dpo_single_device.yaml",
             ),
+            Config(
+                name="qwen2_5/0.5B_lora_single_device",
+                file_path="qwen2_5/0.5B_lora_single_device.yaml",
+            )
         ],
         supports_distributed=False,
     ),


### PR DESCRIPTION
This PR introduces functionality to precompute reference log probabilities for the dataset during the data loading phase. The goal is to improve training efficiency by reducing computations of reference log probabilities during each training loop. This allows us to only maintain the policy model and perform lookups to get reference model values. This feature is controlled by a configuration flag precompute_ref_log_probs.

Notebook showing the execution with Llama-3.1-8B-Instruct and custom torchtune build with the PR changes:
[Precompute_ref_log_prob_DPO_execution](https://colab.research.google.com/drive/1cCwgYZ6997oiahwmAK75rqqqt-QzZ8-e?usp=sharing)